### PR TITLE
AAC-34 - Added better error handling

### DIFF
--- a/src/AudioInputHandler.ts
+++ b/src/AudioInputHandler.ts
@@ -17,6 +17,11 @@ export class AudioInputHandler {
             return;
         }
 
+        if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+            console.error("This device does not support microphone input.")
+            return;
+        }
+
         try {
             // this line asks for user perms and starts rec
             this.stream = await navigator.mediaDevices.getUserMedia({audio: true})
@@ -36,8 +41,16 @@ export class AudioInputHandler {
 
             this.isListening = true;
             console.log("Microphone is listening...")
-        } catch (err) {
-            console.error("You may have denied microphone permissions... please try again");
+        } catch (err: any) {
+            //updating so we dont have generic message and we know why the catch is hitting
+            if (err.name === "NotAllowedError"){
+                console.error("You may have denied microphone permissions... please try again");
+            } else if (err.name === "NotFoundError") {
+                console.error("No microphone was found on this device")
+            } else {
+                console.error("Error accessing Mic: " + err)
+            }
+
         }
     }
 


### PR DESCRIPTION
I know this isnt much but it seems the API already hits the catch block when mic can't be accessed. Decided to just add more detail to the catch based on the error so now when something goes wrong we potentially will have a better idea why, whether its because the user does not have a mic on deck or because they clicked deny on mic permissions. For now the error type will be logged to the console but it may be useful to consider making these `alert` functions or maybe even a modal/toast notification rather that `alert` because alerts can be a little intrusive as you have to manually click okay to get rid of it. A corner timed pop up toast would be informative and less obstructive to the users experience.